### PR TITLE
Disable namespace option linked to assets

### DIFF
--- a/src/modules/services/submodule/assets/routingAssets.js
+++ b/src/modules/services/submodule/assets/routingAssets.js
@@ -16,7 +16,7 @@ export const AssetsRoutes = [
     }
   },
   {
-    path: '/asset-supply-change',
+    path: '/alias-namespace-to-asset',
     name: 'ViewServicesAssetsLinkToNamespace',
     component: () => import('@/modules/services/submodule/assets/views/ViewServicesAssetsLinkToNamespace.vue'),
     meta: {

--- a/src/modules/services/submodule/assets/views/ViewServicesAssetsLinkToNamespace.vue
+++ b/src/modules/services/submodule/assets/views/ViewServicesAssetsLinkToNamespace.vue
@@ -22,12 +22,6 @@
                 <div class="inline-block text-tsm">You are not a cosigner to this account</div>
               </div>
             </div>
-            <div v-if="isNotCosigner" class="border-2 rounded-3xl border-yellow-400 w-full h-24 text-center p-4">
-              <div class="h-5 text-center">
-                <div class="rounded-full w-8 h-8 border border-yellow-500 inline-block relative"><font-awesome-icon icon="exclamation" class="text-yellow-500 h-5 w-5 absolute" style="top: 5px; left:11px"></font-awesome-icon></div><br>
-                <div class="inline-block text-tsm">You are not a cosigner to this account</div>
-              </div>
-            </div>
             <div class="error error_box" v-if="err!=''">{{ err }}</div>
             <div v-if="moreThanOneAccount" class="text-left p-4">
               <div class="mb-1 cursor-pointer z-20 border-b border-gray-200" @click="showMenu = !showMenu">

--- a/src/util/assetsUtils.ts
+++ b/src/util/assetsUtils.ts
@@ -304,7 +304,6 @@ export class AssetsUtils {
         let label:string = '';
         let namespaceName:string = '';
         if(namespaceElement.linkedId != ''){
-          isDisabled = (linkOption=='link'?true:false);
           let linkName:string;
           let linkLabel:string;
 
@@ -312,10 +311,12 @@ export class AssetsUtils {
             case 1:
               linkName = "Asset";
               linkLabel = namespaceElement.linkedId;
+              isDisabled = (linkOption=='link'?true:false);
               break;
             case 2:
               linkName = "Address";
               linkLabel = Helper.createAddress(namespaceElement.linkedId).pretty()
+              isDisabled = true;
               break;
             default:
               break;


### PR DESCRIPTION
- remove duplicate notification in link namespace to asset vue file
- disable namespace option that is already been linked to address in link namespace to asset vue 