### PR TITLE
Added mainnet to chainprofile

### DIFF
--- a/public/ChainSwapProfile.json
+++ b/public/ChainSwapProfile.json
@@ -1,4 +1,34 @@
 {
+    "Sirius Mainnet": {
+      "swapData":{
+        "swap_XPX_ETH_URL": "https://bctestnet-swap-gateway.xpxsirius.io/eth",
+        "swap_XPX_BSC_URL": "https://bctestnet-swap-gateway.xpxsirius.io/bsc",
+        "swap_IN_SERVICE_URL": "https://bctestnet-swap-gateway.xpxsirius.io",
+        "swap_SERVICE_URL": "https://bctestnet-swap-gateway.xpxsirius.io",
+        "gasPriceConsultURL": "https://bctestnet-swap-gateway.xpxsirius.io/gas",
+        "priceConsultURL": "https://bctestnet-swap-gateway.xpxsirius.io",
+        "BSCChainId": 97,
+        "ETHChainId": 3,
+        "BSCScanUrl": "https://testnet.bscscan.com/tx/",
+        "ETHScanUrl": "https://ropsten.etherscan.io/tx/",
+        "BSCNetworkName": "BSC Testnet",
+        "ETHNetworkName": "Ropsten",
+        "nis1SwapData": {
+          "timeOutTransactionNis1": 20000,
+          "url": "https://bctestnetswap.xpxsirius.io:7890",
+          "urlExplorer": "http://testnet-explorer.nemtool.com/#/s_tx?hash=",
+          "networkType": 152,
+          "burnAddress": "TBF4LAZUEJMBIOC6J24D6ZGGXE5W775TX555CTTN",
+          "nodes":[
+            { "protocol": "https", "domain": "bctestnetswap.xpxsirius.io", "port": 7890 }
+          ],
+          "swapAllowedMosaics": [
+            { "namespaceId": "xarcade", "name": "xar", "divisibility": 4 },
+            { "namespaceId": "prx", "name": "xpx", "divisibility": 6 }
+          ]
+        }
+      }
+    },
     "Sirius Testnet 1": {
     },
     "Sirius Testnet 2": {
@@ -15,9 +45,7 @@
         "ETHScanUrl": "https://ropsten.etherscan.io/tx/",
         "BSCNetworkName": "BSC Testnet",
         "ETHNetworkName": "Ropsten",
-
         "nis1SwapData": {
-          
           "timeOutTransactionNis1": 20000,
           "url": "https://bctestnetswap.xpxsirius.io:7890",
           "urlExplorer": "http://testnet-explorer.nemtool.com/#/s_tx?hash=",

--- a/public/ChainSwapProfile.json
+++ b/public/ChainSwapProfile.json
@@ -1,26 +1,26 @@
 {
     "Sirius Mainnet": {
       "swapData":{
-        "swap_XPX_ETH_URL": "https://bctestnet-swap-gateway.xpxsirius.io/eth",
-        "swap_XPX_BSC_URL": "https://bctestnet-swap-gateway.xpxsirius.io/bsc",
-        "swap_IN_SERVICE_URL": "https://bctestnet-swap-gateway.xpxsirius.io",
-        "swap_SERVICE_URL": "https://bctestnet-swap-gateway.xpxsirius.io",
-        "gasPriceConsultURL": "https://bctestnet-swap-gateway.xpxsirius.io/gas",
-        "priceConsultURL": "https://bctestnet-swap-gateway.xpxsirius.io",
-        "BSCChainId": 97,
-        "ETHChainId": 3,
-        "BSCScanUrl": "https://testnet.bscscan.com/tx/",
-        "ETHScanUrl": "https://ropsten.etherscan.io/tx/",
-        "BSCNetworkName": "BSC Testnet",
-        "ETHNetworkName": "Ropsten",
+        "swap_XPX_ETH_URL": "https://swap-gateway.xpxsirius.io/eth",
+        "swap_XPX_BSC_URL": "https://swap-gateway.xpxsirius.io/bsc",
+        "swap_IN_SERVICE_URL": "https://swap-gateway.xpxsirius.io",
+        "swap_SERVICE_URL": "https://swap-gateway.xpxsirius.io",
+        "gasPriceConsultURL": "https://swap-gateway.xpxsirius.io/gas",
+        "priceConsultURL": "https://swap-gateway.xpxsirius.io",
+        "BSCChainId": 56,
+        "ETHChainId": 1,
+        "BSCScanUrl": "https://bscscan.com/tx/",
+        "ETHScanUrl": "https://etherscan.io/tx/",
+        "BSCNetworkName": "BSC",
+        "ETHNetworkName": "Ethereum",
         "nis1SwapData": {
           "timeOutTransactionNis1": 20000,
-          "url": "https://bctestnetswap.xpxsirius.io:7890",
-          "urlExplorer": "http://testnet-explorer.nemtool.com/#/s_tx?hash=",
-          "networkType": 152,
-          "burnAddress": "TBF4LAZUEJMBIOC6J24D6ZGGXE5W775TX555CTTN",
+          "url": "https://swap.brimstone.xpxsirius.io:7890",
+          "urlExplorer": "http://explorer.nemtool.com/#/s_tx?hash=",
+          "networkType": 104,
+          "burnAddress": "ND7WVWPWNTJR75CYC3D73LSVP7WIL7BL77QNT7NZ",
           "nodes":[
-            { "protocol": "https", "domain": "bctestnetswap.xpxsirius.io", "port": 7890 }
+            { "protocol": "https", "domain": "swap.brimstone.xpxsirius.io", "port": 7890 }
           ],
           "swapAllowedMosaics": [
             { "namespaceId": "xarcade", "name": "xar", "divisibility": 4 },

--- a/public/chainProfile.json
+++ b/public/chainProfile.json
@@ -1,4 +1,30 @@
 {
+    "Sirius Mainnet": {
+      "version": "0.7.0",
+      "apiNodes":[
+          "betelgeuse.xpxsirius.io"
+      ],
+      "httpPort": 3000,
+      "generationHash": "10540AD3A1BF46B1A05D8B1CF0252BC9FB2E0B53CFD748262B0CE341CEAFEB6B",
+      "network":{
+        "type": 184,
+        "currency":{
+            "name": "XPX",
+            "namespace": "prx.xpx",
+            "mosaicId": "",
+          "namespaceId": "bffb42a19116bdf6",
+          "divisibility": 6
+      },
+      "chainExplorer": {
+        "url": "https://explorer.xpxsirius.io",
+        "blockRoute": "#/result/blockHeight",
+        "publicKeyRoute": "#/result/publicKey",
+        "addressRoute": "#/result/address",
+        "hashRoute": "#/result/hash",
+        "namespaceInfoRoute": "#/result/namespaceInfo",
+        "assetInfoRoute": "#/result/assetInfo"
+      }
+    },
     "Sirius Testnet 1": {
       "version": "0.0.4",
       "apiNodes":[


### PR DESCRIPTION
Added mainnet config to chainProfile

@shinneng Please take note mainnet property in chainSwapProfile is using the same config as in testnet 2. Swap is only available on testnet 2 at the moment based on the current config