### PR TITLE
fix namespace expiration notification

### DIFF
--- a/src/util/notificationUtils.ts
+++ b/src/util/notificationUtils.ts
@@ -147,7 +147,7 @@ const loadExpiringNamespace = (): Notification[] => {
       let differenceHeight = namespace.endHeight - namespace.startHeight;
       let remainingBlockHeight = namespace.endHeight - AppState.readBlockHeight;
 
-      if(differenceHeight < minBlockBeforeExpire){
+      if(remainingBlockHeight < minBlockBeforeExpire){
         notifications.push({
           id: namespace.idHex,
           type: 'Namespace',


### PR DESCRIPTION
Previously namespace expiration will only show if the created duration is less than 30days but if more than 30days or equal, the notification wont come out even it left few days only .It should be have notification when the expiration time is less than 30 days.