### PR TITLE
Fix duplicate assets in view account asset page

### DIFF
--- a/src/modules/account/views/ViewAccountAssets.vue
+++ b/src/modules/account/views/ViewAccountAssets.vue
@@ -88,9 +88,21 @@ export default {
             });
             });
             
+            mosaicOption=filterDuplicate(mosaicOption)
+            
             return mosaicOption
             
         });
+
+        function filterDuplicate(mosaics){
+            var result = mosaics.reduce((unique, o) => {
+        if(!unique.some(obj => obj.amount === o.amount && obj.id === o.id)){
+          unique.push(o);
+        }
+        return unique;
+        },[]);
+        return result 
+        }
 
         const formatNamespaceName = (namespaceNames) => {
             return namespaceNames.join(" / ")


### PR DESCRIPTION
Sign in and out repeatedly will cause assets data in view account asset page to duplicate